### PR TITLE
geth: polish install docs, add refs, fix APIs, extend testnet section

### DIFF
--- a/views/content/geth.md
+++ b/views/content/geth.md
@@ -4,8 +4,6 @@ The Frontier is the first live release of the Ethereum network. As such you are 
 
 In order to navigate the Frontier, you’ll need to use the command line. If you are not comfortable using it, we strongly advise you to step back, watch from a distance for a while and wait until more user friendly tools are made available. Remember, there are no safety nets and for everything you do here, you are mostly on your own.
 
-
-
 * **Learn More**
   * [What is Ethereum?](http://ethereum.gitbooks.io/frontier-guide/content/ethereum.html)
   * [Safety Caveats](http://ethereum.gitbooks.io/frontier-guide/content/ethereum.html)
@@ -15,15 +13,10 @@ In order to navigate the Frontier, you’ll need to use the command line. If you
 ### Install
 
 The Frontier tool is called Geth (the old english third person singular conjugation of “to go”. Quite appropriate given geth is written in Go). In order to get it, open your command line tool (if you are unsure how to do this, consider waiting for a more user friendly release) and paste the command below. 
-
-
  
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/ethereum/frontier.ethereum.org/master/bin/install.rb)"
 
-
-
 Paste the above one-liner in your terminal for an automated install script. This script will detect your OS and will attempt to install the ethereum CLI. 
-
 
 * **Other ways to install**
   * [Linux (using PPA, build from source)](http://ethereum.gitbooks.io/frontier-guide/content/installing_linux.html)
@@ -35,43 +28,45 @@ Paste the above one-liner in your terminal for an automated install script. This
 
 ### Run it
 
-Geth is a multipurpose command line tool that runs a full Ethereum node implemented in Go. It offers three interfaces: the command line subcommands and options [link], a JSON-RPC server and an interactive console. For the purposes of this guide, we will focus on the Console, a javascript environment that contains all the main features you probably want. 
+Geth is a multipurpose command line tool that runs a full Ethereum node implemented in Go. It offers three interfaces: the [command line](http://ethereum.gitbooks.io/frontier-guide/content/cli.html) subcommands and options, a [JSON-RPC server](http://ethereum.gitbooks.io/frontier-guide/content/rpc.html) and an [interactive console](http://ethereum.gitbooks.io/frontier-guide/content/jsre.html).
 
-To start the console, simply type:
+For the purposes of this guide, we will focus on the Console, a JavaScript environment that contains all the main features you probably want. To start it, simply type:
 
-
- 
     geth console
- 
+
+Tip: Typing **web3** will list all the available packages, fields and functions provided by Geth. The most commonly used you should be aware of are the packages: **admin** (administering your node), **pesonal** (managing your accounts), **miner** (handling mining operations) and **eth** (interacting with the blockchain).
 
 
 ### Alternative ways to running 
 
-You'll notice that there are many warnings popping up on your console, sometimes while you type. This is because all the warnings are logged live to your console as you type. If you want to save the logs to a file you can see later, use this command:
+You'll notice that there are many log entries popping up on your console, sometimes while you type. This is because all the warnings and progress information are logged live by a running node. If you want to save the logs to a file you can see later, use this command:
 
     geth console 2>>geth.log
 
-An even better solution is to run multiple terminal windows with the logs in one and your current task in another. To do this simply open a new terminal window and type _tty_ on the window that you want as a secondary window. It will output something like _/dev/ttys000_. Then back on the original terminal window, type this to start your console: 
+An better solution however, is to run multiple terminal windows with the logs in one and your current task in another. This can be done by attaching a new console to an already running Geth process. This will give you the exact same functionality as the original console, but in a fresh and clean environment.
 
-    geth console 2>>/dev/ttys000
+    geth attach
 
- 
-The geth console has history that persists between sessions. You can navigate your command history by using the up and down arrow keys.
+The console has history that persists between sessions. You can navigate your command history by using the up and down arrow keys.
 
 
 ### Connecting to a private test net
 
-Sometimes you might not need to connect to the live public network, you can instead choose to create your own private testnet. This is very useful if you don't need to test external contracts and want just to test the technology, because since you will be only one mining will you easily get a lot of ether to test your code. Any number of people can connect to your test net by simply providing the same network id.
+Sometimes you might not want to connect to the live public network. Instead, you can choose to create your own private testnet. This is very useful if you don't need to test public contracts and want just to try- or develop on the technology. Since you would be only one mining, you can easily get a lot of ether to test your code. Any number of people can connect to your test net by simply providing the same network identifier.
  
-    geth —networkid 12345 console
+    geth --networkid 12345 console
  
-Replace _12345_ with any random number you want to use as a network ID.
+*Replace 12345 with any random number you want to use as the network ID.*
 
-If you use a private testnet, it may be a good idea to start with a 'fresh' blockchain, and not the real blockchain. Otherwise, in order to successfully mine a block, you'll need to mine against the difficulty of the last block present in your local copy of the blockchain - which may take several hours. This is done via the _--datadir_ parameter: 
+If you use a private testnet, it may be a good idea to start with a 'fresh' blockchain, and not the real one. Otherwise, in order to successfully mine a block, you would need to mine against the difficulty of the last block present in your local copy of the blockchain - which may take several hours. This is done via the _--datadir_ CLI argument: 
 
- 
-    geth --networkid=-12345 --datadir=~/.ethereum_experiment console
- 
+    geth --networkid 12345 --datadir ~/.ethereum_experiment console
+
+The above command will run Geth on a new private network, with a possibly pristine blockchain from the specified data directory. This chain will however still be compatible with the canonical blockchain, so if someone accidentally connects to your testnet using the real chain, your local copy will be considered a stale fork and updated to the real one. To prevent this, you can make your test chain incompatible by changing the point of origin, the *genesis block*.
+
+    geth --networkid 12345 --genesisnonce 314 --datadir ~/.ethereum_experiment console
+
+This will prevent anyone who doesn't know your chosen - secret - nonce, from connecting to you or providing you with unwanted data.
 
 * **Learn More**
   * [Backup and restore](http://ethereum.gitbooks.io/frontier-guide/content/backup_restore.html)
@@ -82,62 +77,29 @@ If you use a private testnet, it may be a good idea to start with a 'fresh' bloc
 
 ### Creating accounts
 
+In order to do most actions in Ethereum you need ether, and to get it, you will need to generate an account. There are [various ways to go around this](http://ethereum.gitbooks.io/frontier-guide/content/managing_accounts.html), but the simplest one is through the Geth console:
 
-In order to do most actions in Ethereum you need ether, and to get it, you will need to generate an address (see here for detailed documentation on managing your accounts). Type: 
+    personal.newAccount("Write here a good, randomly generated, passphrase!")
 
+**Note: Pick up a good passphrase and write it down. If you lose the passphrase you used to encrypt your account, you will not be able to access that account. Repeat: There are no safety nets. It is NOT possible to access your account without a valid passphrase and there is no "forgot my password" option here.**
 
- 
-    var passphrase = "Write here a good, randomly generated, passphrase!"
-    personal.newAccount(passphrase)
- 
+**DO NOT FORGET YOUR PASSPHRASE! **
 
-
-**Pick up a good passphrase and write it down. If you lose the passphrase you use to encrypt your account, you will not be able to access that account. Repeat: It is NOT possible to access your account without a passphrase and there is no forgot my password option here.**
-
-**DO NOT FORGET YOUR PASSPHRASE. **
-
-*tip: you can create short but random passphrases by using this simple command:
-
-    var passphrase = (Math.random()*1000000000).toString(36)
-
-Tip: Typing “admin” by itself will bring up a list of sub commands used to administer your geth installation.
-
-The Following command generates an address and associates it with your local machine. You can create multiple accounts by executing the same command again. Go on, try it:
-
-
- 
-    admin.newAccount()
- 
-
-
-By convention we call the first account you create your primary account. You can see all your accounts with the command:
-
-
+You may create as many or as few accounts as you like. By convention we call the first account you create your primary account. You can see all your accounts with the command:
  
     eth.accounts
- 
+
 
 ### Get the balance of any account
 
-All commands on the console are actually in javascript, so you can create variables and daisy chain functions. You can also write any “eth” function as “web3.eth” since it’s actually part of the main “web3” object.
+All commands on the console are actually in JavaScript, so you can create variables and daisy chain functions. You can also write any “eth” function as “web3.eth” since it’s actually part of the main “web3” object.
 
 Try this for example:
 
- 
     var primaryAccount = eth.accounts[0]
- 
-
 
 You now have a variable called primaryAccount that you can use in other calls. To get the balance of any account, use the function _eth.getBalance_, like this:
 
-
- 
     eth.getBalance(primaryAccount)
 
-
- Your balance should return 0, since you just created it. In order to do the next steps you need to have some ether in your account so you can pay the gas costs. In the next section, you'll learn how you can do that.
-
-
-
-
-
+ Your balance should return 0, since you just created it. In order to do the next steps you need to have some ether in your account so you can pay the gas costs. In the next section you'll learn what gas is, and how you can interact with the network.


### PR DESCRIPTION
I've mostly made polishes to the text of the geth installation document to make it clearer. Most invasive modifications were:
- Rewritten the alternative console section to use the attach method instead of the complex tty black magic.
- Extended the private network with an extra part detailing how you can create blockchains incompatible with the canonical chain to prevent accidental overwrites.
- Deleted (!) the part with the code snippet generating random passwords. How people generate passwords should imho not be our concern, and given that the code snippet generated a trivially crackable 6 character password, it would look very bad of us to suggest anyone to use that.
