### PR TITLE
views: convert recipes to mixins for mutliple reuse

### DIFF
--- a/views/crowdsale.jade
+++ b/views/crowdsale.jade
@@ -1,6 +1,7 @@
 extends layout
 
 block content
+  include mixins/recipes.jade
   include warning.jade
 
   div#tutorial-start.main-tutorial.inner-tutorial.even
@@ -13,7 +14,6 @@ block content
             a(href="/token").previous Previous 
             a(href="/dao").next Next 
           
-
          figure.crowdsale.scrollme
             div.crowdsale-logic.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-100", data-easing="linear")
             div.crowdsale-robot.animateme(data-when="enter", data-from="0.5", data-to="0.3", data-opacity="0", data-translatey="-155", data-translatex="-30", data-scale="1.1", data-rotatez="90", data-easing="linear")
@@ -33,56 +33,8 @@ block content
         div.col-md-12
           include:md content/crowdsale.md        
 
-
   div.main-tutorial.hidden.even
     div.container   
       div.row
         div.col-md-12.tutorial
-              
-          figure.dao.scrollme
-            div.dao-robot.animateme(data-when="enter", data-from="0.65", data-to="0.45", data-opacity="0", data-translatey="200", data-rotatez="-90")
-            div.dao-money.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200")
-            div.dao-arrows.animateme(data-when="enter", data-from="0.95", data-to="0.8", data-opacity="0", data-scale="1.5")
-            div.dao-crowd.animateme(data-when="enter", data-from="0.45", data-to="0", data-opacity="0", data-translatey="-250", data-translatex="10", data-rotatez="0", data-scale="1.1", data-easing="linear")
-            div.dao-ideas.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-40")
-          h2 what’s Next
-          h3 
-           div.number 6 
-           | Create a democratic autonomous organization
-
-          p Now you have an idea, the funds and a lot of backers, what’s next? You have to now to hire managers, find a trustable CFO to handle the funds, do board meetings, do a bunch of paperwork. Or you can simply leave that to an ethereum contract. It will accept proposals by any of your contributors and then put it them all to a transparent vote.
-
-          p One of the advantadges of having a robot run your organization is that it is immune to any outside influence and it’s guaranteed to execute only what it is programmed to do. Also your organization will never go offline or disappear and will always be available as long as the network exists.
-
-          a(href="dao").button Start your organization 
-
-          div.recipe
-            h4 You'll need:
-            ul
-              li 
-                input(type="checkbox") 
-                a(href="geth") Geth 
-              li 
-                input(type="checkbox") 
-                | Basic programming skills 
-              li 
-                input(type="checkbox") 
-                | 0.008 ether to create the contract 
-                          
-              li 
-                  input(type="checkbox") 
-                  | an ethereum-based 
-                  a(href="token") digital token  
-                  | (will serve as a voting right) 
-
-              li 
-                input(type="checkbox") 
-                a(href="crowdsale") Any amount of funds
-
-              li 
-                input(type="checkbox") 
-                | A bunch of ideas on where to spend your funds
-              li 
-                input(type="checkbox") 
-                | Friends to vote on these ideas (optional)
-
+          +daoRecipe("What's next?")

--- a/views/crowdsale.jade
+++ b/views/crowdsale.jade
@@ -14,12 +14,7 @@ block content
             a(href="/token").previous Previous 
             a(href="/dao").next Next 
           
-         figure.crowdsale.scrollme
-            div.crowdsale-logic.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-100", data-easing="linear")
-            div.crowdsale-robot.animateme(data-when="enter", data-from="0.5", data-to="0.3", data-opacity="0", data-translatey="-155", data-translatex="-30", data-scale="1.1", data-rotatez="90", data-easing="linear")
-            div.crowdsale-money.animateme(data-when="enter", data-from="0.8", data-to="0.6", data-opacity="0",data-translatey="-20")
-            div.crowdsale-contributions.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-scale="1.4")
-            div.crowdsale-crowd.animateme(data-when="enter", data-from="0.3", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.1", data-easing="linear")
+          +crowdsaleFigure
 
           h2.animateme(data-when="span", data-from="0.6", data-to="0.3", data-opacity="0", data-translatey="200") The Crowdsale
 

--- a/views/dao.jade
+++ b/views/dao.jade
@@ -13,11 +13,7 @@ block content
             strong »  Start a democratic organization
             a(href="/crowdsale").previous Previous 
           
-          figure.dao.scrollme
-            div.dao-robot.animateme(data-when="enter", data-from="0.65", data-to="0.45", data-opacity="0", data-translatey="200", data-rotatez="-90")
-            div.dao-money.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200")
-            div.dao-arrows.animateme(data-when="enter", data-from="0.95", data-to="0.8", data-opacity="0", data-scale="1.5")
-            div.dao-crowd.animateme(data-when="enter", data-from="0.45", data-to="0", data-opacity="0", data-translatey="-250", data-translatex="10", data-rotatez="0", data-scale="1.1", data-easing="linear")
+          +daoFigure
 
           h2.animateme(data-when="span", data-from="0.6", data-to="0.3", data-opacity="0", data-translatey="200") Democratic Autonomous Organization
 

--- a/views/dao.jade
+++ b/views/dao.jade
@@ -1,6 +1,7 @@
 extends layout
 
 block content
+  include mixins/recipes.jade
   include warning.jade
 
   div#tutorial-start.main-tutorial.inner-tutorial.even
@@ -12,7 +13,6 @@ block content
             strong »  Start a democratic organization
             a(href="/crowdsale").previous Previous 
           
-  
           figure.dao.scrollme
             div.dao-robot.animateme(data-when="enter", data-from="0.65", data-to="0.45", data-opacity="0", data-translatey="200", data-rotatez="-90")
             div.dao-money.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200")
@@ -31,61 +31,8 @@ block content
         div.col-md-12
           include:md content/dao.md        
 
-
   div.main-tutorial.ethereum-projects.even
     div.container   
       div.row
         div.col-md-12
-
-          figure.moon.scrollme
-            div.moon-stars.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="360", data-easing="linear")
-            div.moon-moon.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="720", data-easing="linear")
-            div.moon-rocket.animateme(data-when="span", data-from="0", data-to="1", data-translatey="-200", data-easing="linear")
-            
-          h2 What's next?
-          h3 Your imagination is the limit!
-
-          p Now it's your turn: start building what you want to create in ethereum! Could your business be enhanced by existing in a cryptographically secure, decentralized, tamper proof network?
-
-          p There are many great projects being built right now, you should check them. And since you are among the very few people in the world that can program a decentralized app, maybe some of them might need your help!
-
-          h4 Some projects using Ethereum
-
-          ul
-            li
-              a(href='http://augur.net') Augur 
-              | Decentralized prediction market built on Ethereum
-
-            li 
-              a(href='https://etherex.org/') Etherex 
-              | Ethereum based opensource exchange
-            li
-              a(href='https://www.theprotocol.tv/adept-demo-ibm-samsung') IBM 
-              | IBM/Samsung Internet of Things project
-            li 
-              a(href='http://ether.fund') Ether.fund              
-              | Ethereum blockchain services
-            
-            li 
-              a(href='http://ethergit.com') Ether Git 
-              | Ethereum blockchain explorer
-
-            li 
-              a(href='http://airlock.me/') Airlock             
-              | Next generation keyless access protocol for smart property
-            li 
-              a(href='https://www.provenance.org') Provenance            
-              | Social business founded to open up the world of how things are made
-            li 
-              a(href='https://dgx.io/') DigiGlobal           
-              | the first Smart Asset company built on Ethereum
-            li 
-              a(href='http://weifund.io/') Wei.fund             
-              | A non-profit, decentralized crowdfunding platform built on Ethereum
-            li 
-              a(href='http://www.lazooz.net/')  Lazzoz            
-              | Decentralized Collaborative Transportation Web
-            li 
-              a(href='http://main.cubespawn.com') Cubespawn 
-              | Open source project to build cost sensitive, high quality, modular manufacturing machines
-
+          +futureRecipe("What's next?")

--- a/views/ether.jade
+++ b/views/ether.jade
@@ -1,8 +1,8 @@
 extends layout
 
 block content
+  include mixins/recipes.jade
   include warning.jade
-
 
   div#tutorial-start.main-tutorial.inner-tutorial.even
     div.container
@@ -33,43 +33,8 @@ block content
         div.col-md-12
           include:md content/ether.md        
 
-
   div.main-tutorial.hidden.even
     div.container   
       div.row
         div.col-md-12.tutorial
-            figure.greeter.scrollme
-              div.greeter-human.animateme(data-when="enter", data-from="0.4", data-to="0", data-opacity="0", data-translatex="-200")
-              div.greeter-robot.animateme(data-when="enter", data-from="0.5", data-to="0.2", data-opacity="0", data-translatex="200")
-              div.greeter-question.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0")
-              div.greeter-answer.animateme(data-when="enter", data-from="0.9", data-to="0.6", data-opacity="0")
-
-            h2 What's next?
-            h3 
-             div.number 3 
-             | Create the Greeter, your first live contract
-
-            p The greeter is a very simple contract that greets “Hello” when you poke it. It includes a very simple upgrade that turns it into a contract that will charge for telling jokes.
-
-
-            a(href="greeter/").button Summon the Greeter 
-
-            div.recipe
-              h4 You'll need:
-              ul
-                li 
-                  input(type="checkbox") 
-                  a(href="geth") Geth 
-                li 
-                  input(type="checkbox") 
-                  |  Desire to learn new things  
-                li 
-                  input(type="checkbox") 
-                  |  0.001 ether (approximatelly)
-                li 
-                  input(type="checkbox") 
-                  |  1 "knock knock" joke (optional)
-
-
-
-          
+            +greeterRecipe("What's next?")

--- a/views/ether.jade
+++ b/views/ether.jade
@@ -14,12 +14,7 @@ block content
             a(href="/geth").previous Previous 
             a(href="/greeter").next Next 
 
-          figure.ether.scrollme
-            div.ether-screen.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-            div.ether-pacman.animateme(data-when="span", data-from="0.6", data-to="0.5", data-opacity="0")
-            div.ether-arcade-back.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-            div.ether-coin.animateme(data-when="span", data-from="0.6", data-to="0.4", data-translatey="-300")
-            div.ether-arcade-front.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
+          +etherFigure
 
           h2.animateme(data-when="span", data-from="0.6", data-to="0.3", data-opacity="0", data-translatey="200") Get Ether
 

--- a/views/geth.jade
+++ b/views/geth.jade
@@ -1,8 +1,8 @@
 extends layout
 
 block content
+  include mixins/recipes.jade
   include warning.jade
-
 
   div#tutorial-start.main-tutorial.inner-tutorial.even
     div.container
@@ -12,7 +12,6 @@ block content
             a(href="/").index Ethereum Frontier 
             strong » Installing Geth 
             a(href="/ether").next Next 
-
 
           figure.geth.scrollme
             div.geth-background.animateme(data-when="span", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100")
@@ -30,52 +29,8 @@ block content
         div.col-md-12
           include:md content/geth.md        
 
-
   div.main-tutorial.hidden.even
     div.container   
       div.row
         div.col-md-12.tutorial
-           
-          figure.ether.scrollme
-            div.ether-screen.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-            div.ether-pacman.animateme(data-when="span", data-from="0.6", data-to="0.5", data-opacity="0")
-            div.ether-arcade-back.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-            div.ether-coin.animateme(data-when="span", data-from="0.6", data-to="0.4", data-translatey="-300")
-            div.ether-arcade-front.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-
-          
-          h2 What's next
-          h3 
-           div.number 2 
-           | Get Ether, the crypto-fuel of the ethereum network
-
-          p Ether is the internal currency of the system. All programs running on ethereum need to pay for their time in ether, and anyone can setup a computer executing those computations to earn ether. If you donated to fund Ethereum development or if you participated on our bug bounty program, you should have a file with a claim for ether. Otherwise you can get some from a friend, by exchanging it with bitcoin or in one of the sites that give away free ether.
-
-          a(href="ether").button get Ether 
-
-          div.recipe
-            h4 You'll need:
-            ul
-              li 
-                input(type="checkbox") 
-                a(href="#install-geth") Geth 
-              li 
-                input(type="checkbox") 
-                |  One of these:
-                ul
-                  li 
-                    input(type="checkbox") 
-                    |  an active Github account, or..
-                  li 
-                    input(type="checkbox") 
-                    |  Bitcoins, or...
-                  li 
-                    input(type="checkbox") 
-                    |  computer with a good dedicated graphics card, or...
-                  li 
-                    input(type="checkbox") 
-                    em if you participated in the presale, 
-                    | the .json file you downloaded after contributing, or… 
-                  li 
-                    input(type="checkbox") 
-                    |  a friend that can give you ether 
+          +etherRecipe("What's next?")

--- a/views/geth.jade
+++ b/views/geth.jade
@@ -13,9 +13,7 @@ block content
             strong » Installing Geth 
             a(href="/ether").next Next 
 
-          figure.geth.scrollme
-            div.geth-background.animateme(data-when="span", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100")
-            div.geth-logo.animateme(data-when="span", data-from="0.7", data-to="0.5", data-opacity="0")
+          +gethFigure(true)
 
           h2.animateme(data-when="span", data-from="0.6", data-to="0.3", data-opacity="0", data-translatey="200") Installing Geth
 

--- a/views/greeter.jade
+++ b/views/greeter.jade
@@ -1,6 +1,7 @@
 extends layout
 
 block content
+  include mixins/recipes.jade
   include warning.jade
 
   div#tutorial-start.main-tutorial.hidden.inner-tutorial.even
@@ -31,43 +32,8 @@ block content
         div.col-md-12
           include:md content/greeter.md        
 
-
   div.main-tutorial.hidden.even
     div.container   
       div.row
         div.col-md-12.tutorial
-          figure.coin.scrollme
-            div.coin-connection.animateme(data-when="enter", data-from="1", data-to="0.5", data-opacity="0", data-translatey="0")
-            div.coin-send.animateme(data-when="enter", data-from="0.9", data-to="0.8", data-opacity="0", data-translatey="-50", data-translatex="-200")
-            div.coin-users.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.5", data-rotate="45")
-            div.coin-coins.animateme(data-when="enter", data-from="0.6", data-to="0.4", data-opacity="0", data-scale="0.5", data-translatey="-10")
-            
-          h2 What's next?
-          
-          h3 
-           div.number 4
-           | Design and issue your own cryptocurrency
-
-          p Create a tradeable digital token that can be used as a currency, a representation of an asset, a virtual share, proof of membership or anything you want. These tokens use a standard coin api, so it will be automatically compatible with any wallet, contract or exchange that also uses the same standard. The total amount of tokens in circulation can be controlled by anything you can program into it, or simply set to a fixed constant amount.
-
-          a(href="../token").button Issue your token 
-
-          div.recipe
-            h4 You'll need:
-            ul
-              li 
-                input(type="checkbox") 
-                a(href="../geth") Geth 
-              li 
-                input(type="checkbox") 
-                |  Very basic programming skills 
-              li 
-                input(type="checkbox") 
-                |  0.002 ether (approximatelly)
-              li 
-                input(type="checkbox") 
-                |  1 cool coin name (optional)
-
-
-          
-
+          +tokenRecipe("What's next?")

--- a/views/greeter.jade
+++ b/views/greeter.jade
@@ -14,12 +14,8 @@ block content
             a(href="/ether").previous Previous 
             a(href="/token").next Next 
 
-          figure.greeter.scrollme
-            div.greeter-human.animateme(data-when="enter", data-from="0.4", data-to="0", data-opacity="0", data-translatex="-200")
-            div.greeter-robot.animateme(data-when="enter", data-from="0.5", data-to="0.2", data-opacity="0", data-translatex="200")
-            div.greeter-question.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0")
-            div.greeter-answer.animateme(data-when="enter", data-from="0.9", data-to="0.6", data-opacity="0")
-         
+          +greeterFigure
+
           h2.animateme(data-when="span", data-from="0.6", data-to="0.3", data-opacity="0", data-translatey="200") The Greeter
 
           h3.center.animateme(data-when="span", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200") Your Digital Pal Who's Fun to Be With

--- a/views/includes/recipes.jade
+++ b/views/includes/recipes.jade
@@ -1,8 +1,9 @@
+include ../mixins/recipes.jade
+
 div.main-tutorial
   div.container
     div.row
       div.col-md-12.tutorial.scrollme
-
         h2.animateme(data-when="enter", data-from="0.7", data-to="0", data-opacity="0", data-translatey="200") WHAT CAN I DO WITH ETHEREUM FRONTIER RELEASE?
 
         h3.center.animateme(data-when="enter", data-from="0.8", data-to="0.2", data-opacity="0", data-translatey="200") Well it depends on what you want. Here are some recipe ideas:
@@ -11,324 +12,40 @@ div.main-tutorial.even#install-geth
   div.container   
     div.row
       div.col-md-12
-
-        figure.geth.scrollme
-          div.geth-background.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatex="100")
-          div.geth-logo.animateme(data-when="enter", data-from="0.7", data-to="0.6", data-opacity="0")
-
-        h3 
-         div.number 1 
-         | Run and Setup 
-         strong Geth
-         | , the Command Line Interface
-
-        p Geth is the main tool of the Frontier release. You can use it to test the network, send ether (the network’s internal currency),  execute contracts, unlock your presale ether or make your computer into a supporting node to earn ether (ie. “mining”).
-
-        a(href="geth").button Install Geth
-
-        div.recipe
-          h4 You'll need:
-          ul
-            li 
-              input(type="checkbox") 
-              | Know how to use a command-line interface 
-            li 
-              input(type="checkbox") 
-              |  500 Mb free space (for the blockchain) 
-            li 
-              input(type="checkbox") 
-              |  Not be afraid of basic coding
-            
+        +gethRecipe()
 
 div.main-tutorial#get-ether
   div.container   
     div.row
-      div.col-md-12    
-        figure.ether.scrollme
-          div.ether-screen.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-          div.ether-pacman.animateme(data-when="span", data-from="0.6", data-to="0.5", data-opacity="0")
-          div.ether-arcade-back.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-          div.ether-coin.animateme(data-when="span", data-from="0.6", data-to="0.4", data-translatey="-300")
-          div.ether-arcade-front.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-          
-        h3 
-         div.number 2 
-         | Get Ether, the crypto-fuel of the Ethereum network
-
-        p Ether is the internal currency of the system. All programs running on Ethereum need to pay the network for the consumed resources in ether, and <strong>anyone can setup a computer executing those programs to earn ether ("mining")</strong>. If you participated in the presale to fund Ethereum development or in one of our bug bounty programs, you should have a wallet file (.json) that will allow you to unlock your ether.
-
-        p Otherwise you can get some from a friend; exchange bitcoin for it; or from one of the sites that give away free ether.
-
-
-
-        a(href="ether").button Get Ether
-
-        div.recipe
-          h4 You'll need:
-          ul
-            li 
-              input(type="checkbox") 
-              a(href="#install-geth") Geth 
-            li 
-              input(type="checkbox") 
-              |  One of these:
-              ul
-                li 
-                  input(type="checkbox") 
-                  |  Active Github account
-                li 
-                  input(type="checkbox") 
-                  |  Bitcoins to exchange
-                li 
-                  input(type="checkbox") 
-                  |  Computer with a modern GPU
-                li 
-                  input(type="checkbox") 
-                  |  Ether presale wallet
-                li 
-                  input(type="checkbox") 
-                  |  Generous friend with ether
+      div.col-md-12
+        +etherRecipe()
 
 div.main-tutorial.even
   div.container   
     div.row
       div.col-md-12.tutorial
-          figure.greeter.scrollme
-            div.greeter-human.animateme(data-when="enter", data-from="0.4", data-to="0", data-opacity="0", data-translatex="-200")
-            div.greeter-robot.animateme(data-when="enter", data-from="0.5", data-to="0.2", data-opacity="0", data-translatex="200")
-            div.greeter-question.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0")
-            div.greeter-answer.animateme(data-when="enter", data-from="0.9", data-to="0.6", data-opacity="0")
-
-          h3 
-           div.number 3 
-           | Create the Greeter, your first live contract
-
-          p The greeter is a very simple contract that greets “Hello” when you poke it. It includes a very simple upgrade that turns it into a contract that will charge for telling jokes.
-
-
-          a(href="greeter").button Summon the Greeter 
-
-          div.recipe
-            h4 You'll need:
-            ul
-              li 
-                input(type="checkbox") 
-                a(href="#install-geth") Geth 
-              li 
-                input(type="checkbox") 
-                |  Desire to learn new things  
-              li 
-                input(type="checkbox") 
-                |  0.001 
-                a(href="#get-ether") ether 
-                | (approximatelly)
-              li 
-                input(type="checkbox") 
-                |  1 "knock knock" joke (optional)
-
-
+        +greeterRecipe()
 
 div.main-tutorial#crypto-currency
   div.container   
     div.row
       div.col-md-12
-
-        figure.coin.scrollme
-          div.coin-connection.animateme(data-when="enter", data-from="1", data-to="0.5", data-opacity="0", data-translatey="0")
-          div.coin-send.animateme(data-when="enter", data-from="0.9", data-to="0.8", data-opacity="0", data-translatey="-50", data-translatex="-200")
-          div.coin-users.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.5", data-rotate="45")
-          div.coin-coins.animateme(data-when="enter", data-from="0.6", data-to="0.4", data-opacity="0", data-scale="0.5", data-translatey="-10")
-
-        h3 
-         div.number 4 
-         | Design and issue your own cryptocurrency
-
-        p Create a tradeable digital token that can be used as a currency, a representation of an asset, a virtual share, proof of membership or anything you want. These tokens use a standard coin API, so it will be automatically compatible with any wallet, contract or exchange that also uses the same standard. The total amount of tokens in circulation can be controlled by anything you can program into it, or simply set to a fixed constant amount.
-
-        a(href="token").button Issue your token 
-
-        div.recipe
-          h4 You'll need:
-          ul
-            li 
-              input(type="checkbox") 
-              a(href="#install-geth") Geth 
-            li 
-              input(type="checkbox") 
-              |  Very basic programming skills 
-            li 
-              input(type="checkbox") 
-              |  0.002  
-              a(href="#get-ether") ether 
-              | (approximatelly)
-            li 
-              input(type="checkbox") 
-              |  1 cool coin name (optional)
+        +tokenRecipe()
 
 div.main-tutorial.even#crowdsale
   div.container   
     div.row
       div.col-md-12.tutorial
-          figure.crowdsale.scrollme
-            div.crowdsale-logic.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-100", data-easing="linear")
-            div.crowdsale-robot.animateme(data-when="enter", data-from="0.5", data-to="0.3", data-opacity="0", data-translatey="-155", data-translatex="-30", data-scale="1.1", data-rotatez="90", data-easing="linear")
-            div.crowdsale-money.animateme(data-when="enter", data-from="0.8", data-to="0.6", data-opacity="0",data-translatey="-20")
-            div.crowdsale-contributions.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-scale="1.4")
-            div.crowdsale-crowd.animateme(data-when="enter", data-from="0.3", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.1", data-easing="linear")
-
-          h3 
-           div.number 5 
-           | Kickstart a project with a trustless crowdsale
-
-          p Are you already full of ideas to develop things in Ethereum? Maybe now you need some help and some funds to do that, but who would give money to someone they don’t trust?
-
-          p Using Ethereum you can create a contract that will hold contributors money until either a specific date or a given amount is reached. Depending on the outcome, the money is moved either to the project, or back to the contributors. All without requiring a central service provider, a clearing house or having to trust anyone. 
-
-          p You can even use the token you just created to keep track of ownership of prizes.
-
-
-          a(href="crowdsale").button Kickstart your project 
-
-          div.recipe
-            h4 You'll need:
-            ul
-              li 
-                input(type="checkbox") 
-                a(href="#install-geth") Geth 
-              li 
-                input(type="checkbox") 
-                | Basic programming skills 
-              li 
-                input(type="checkbox") 
-                | 0.004  
-                a(href="#get-ether") ether 
-                | (approximatelly)
-              li 
-                input(type="checkbox") 
-                | Ethereum-based
-                a(href="#crypto-currency") digital token 
-                | (track rewards)
-              li 
-                input(type="checkbox") 
-                | 1 good idea that needs funding
-
+        +crowdsaleRecipe()
 
 div.main-tutorial
   div.container   
     div.row
       div.col-md-12
-
-        figure.dao.scrollme
-          div.dao-robot.animateme(data-when="enter", data-from="0.65", data-to="0.45", data-opacity="0", data-translatey="200", data-rotatez="-90")
-          div.dao-money.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200")
-          div.dao-arrows.animateme(data-when="enter", data-from="0.95", data-to="0.8", data-opacity="0", data-scale="1.5")
-          div.dao-crowd.animateme(data-when="enter", data-from="0.45", data-to="0", data-opacity="0", data-translatey="-250", data-translatex="10", data-rotatez="0", data-scale="1.1", data-easing="linear")
-          div.dao-ideas.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-40")
-
-        h3 
-         div.number 6 
-         | Create a democratic autonomous organization
-
-        p Now you have an idea, the funds and a lot of backers, what’s next? You now have to hire managers, find a trustable CFO to handle the funds, do board meetings and a bunch of paperwork. Or you can simply leave that to an Ethereum contract. It will accept proposals by any of your contributors and then put them all to a transparent vote.
-
-        p One of the advantadges of having a robot run your organization is that it is immune to any outside influence and it’s guaranteed to execute only what it is programmed to do. Your organization will never go offline or disappear and will always be available as long as the network exists.
-
-        a(href="dao").button Start your organization 
-
-        div.recipe
-          h4 You'll need:
-          ul
-            li 
-              input(type="checkbox") 
-              a(href="#install-geth") Geth 
-            li 
-              input(type="checkbox") 
-              | Basic programming skills 
-            li 
-              input(type="checkbox") 
-              | 0.008  
-              a(href="#get-ether") ether 
-              | (approximatelly) to create the contract 
-                        
-            li 
-                input(type="checkbox") 
-                | Ethereum-based
-                a(href="#crypto-currency") digital token  
-                | (voting right)
-
-            li 
-              input(type="checkbox") 
-              a(href="#crowdsale") Any amount of funds
-
-            li 
-              input(type="checkbox") 
-              | Bunch of ideas on where to spend your funds
-            li 
-              input(type="checkbox") 
-              | Friends to vote on these ideas (optional)
-
+        +daoRecipe()
 
 div.main-tutorial.even.ethereum-projects 
   div.container   
     div.row
       div.col-md-12
-
-        figure.moon.scrollme
-          div.moon-stars.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="360", data-easing="linear")
-          div.moon-moon.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="720", data-easing="linear")
-          div.moon-rocket.animateme(data-when="span", data-from="0", data-to="1", data-translatey="-200", data-easing="linear")
-          
-        h3 
-         div.number 7 
-         | Build a new kind of decentralized application
-
-        p Now it's your turn: start building what you want to create in Ethereum! Could your business be enhanced by existing in a cryptographically secure, decentralized, tamper proof network?
-
-        p There are many great projects being built right now, you should check them out. And since you are among the very few people in the world that can program a decentralized app, maybe some of them might need your help!
-
-        h4 Some projects using Ethereum
-
-        ul
-          li
-            a(href='http://augur.net') Augur 
-            | Decentralized prediction market built on Ethereum
-
-          li 
-            a(href='https://etherex.org/') Etherex 
-            | Ethereum based opensource exchange
-          li
-            a(href='https://www.theprotocol.tv/adept-demo-ibm-samsung') IBM 
-            | IBM/Samsung Internet of Things project
-          li 
-            a(href='http://ether.fund') Ether.fund              
-            | Ethereum blockchain services
-          
-          li 
-            a(href='http://ethergit.com') Ether Git 
-            | Ethereum blockchain explorer
-
-          li 
-            a(href='http://airlock.me/') Airlock             
-            | Next generation keyless access protocol for smart property
-          li 
-            a(href='https://www.provenance.org') Provenance            
-            | Social business founded to open up the world of how things are made
-          li 
-            a(href='https://dgx.io/') DigiGlobal           
-            | the first Smart Asset company built on Ethereum
-          li 
-            a(href='http://weifund.io/') Wei.fund             
-            | A non-profit, decentralized crowdfunding platform built on Ethereum
-          li 
-            a(href='http://www.lazooz.net/')  Lazzoz            
-            | Decentralized Collaborative Transportation Web
-          li 
-            a(href='http://slock.it') Slock.it 
-            | "If you can lock it, we will let you rent, sell or share it."
-
-          li 
-            a(href='http://main.cubespawn.com') Cubespawn 
-            | Open source project to build cost sensitive, high quality, modular manufacturing machines
-
-
-
+        +futureRecipe()

--- a/views/includes/recipes.jade
+++ b/views/includes/recipes.jade
@@ -12,40 +12,40 @@ div.main-tutorial.even#install-geth
   div.container   
     div.row
       div.col-md-12
-        +gethRecipe()
+        +gethRecipe
 
 div.main-tutorial#get-ether
   div.container   
     div.row
       div.col-md-12
-        +etherRecipe()
+        +etherRecipe
 
 div.main-tutorial.even
   div.container   
     div.row
       div.col-md-12.tutorial
-        +greeterRecipe()
+        +greeterRecipe
 
 div.main-tutorial#crypto-currency
   div.container   
     div.row
       div.col-md-12
-        +tokenRecipe()
+        +tokenRecipe
 
 div.main-tutorial.even#crowdsale
   div.container   
     div.row
       div.col-md-12.tutorial
-        +crowdsaleRecipe()
+        +crowdsaleRecipe
 
 div.main-tutorial
   div.container   
     div.row
       div.col-md-12
-        +daoRecipe()
+        +daoRecipe
 
 div.main-tutorial.even.ethereum-projects 
   div.container   
     div.row
       div.col-md-12
-        +futureRecipe()
+        +futureRecipe

--- a/views/mixins/figures.jade
+++ b/views/mixins/figures.jade
@@ -1,0 +1,59 @@
+mixin gethFigure(center)
+  if center 
+    figure.geth.scrollme
+      div.geth-background.animateme(data-when="span", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100")
+      div.geth-logo.animateme(data-when="span", data-from="0.7", data-to="0.5", data-opacity="0")
+  else
+    figure.geth.scrollme
+      div.geth-background.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatex="100")
+      div.geth-logo.animateme(data-when="enter", data-from="0.7", data-to="0.6", data-opacity="0")
+
+
+mixin etherFigure()
+  figure.ether.scrollme
+    div.ether-screen.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
+    div.ether-pacman.animateme(data-when="span", data-from="0.6", data-to="0.5", data-opacity="0")
+    div.ether-arcade-back.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
+    div.ether-coin.animateme(data-when="span", data-from="0.6", data-to="0.4", data-translatey="-300")
+    div.ether-arcade-front.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
+
+
+mixin greeterFigure()
+  figure.greeter.scrollme
+    div.greeter-human.animateme(data-when="enter", data-from="0.4", data-to="0", data-opacity="0", data-translatex="-200")
+    div.greeter-robot.animateme(data-when="enter", data-from="0.5", data-to="0.2", data-opacity="0", data-translatex="200")
+    div.greeter-question.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0")
+    div.greeter-answer.animateme(data-when="enter", data-from="0.9", data-to="0.6", data-opacity="0")
+
+
+mixin tokenFigure()
+  figure.coin.scrollme
+    div.coin-connection.animateme(data-when="enter", data-from="1", data-to="0.5", data-opacity="0", data-translatey="0")
+    div.coin-send.animateme(data-when="enter", data-from="0.9", data-to="0.8", data-opacity="0", data-translatey="-50", data-translatex="-200")
+    div.coin-users.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.5", data-rotate="45")
+    div.coin-coins.animateme(data-when="enter", data-from="0.6", data-to="0.4", data-opacity="0", data-scale="0.5", data-translatey="-10")
+
+
+mixin crowdsaleFigure()
+  figure.crowdsale.scrollme
+    div.crowdsale-logic.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-100", data-easing="linear")
+    div.crowdsale-robot.animateme(data-when="enter", data-from="0.5", data-to="0.3", data-opacity="0", data-translatey="-155", data-translatex="-30", data-scale="1.1", data-rotatez="90", data-easing="linear")
+    div.crowdsale-money.animateme(data-when="enter", data-from="0.8", data-to="0.6", data-opacity="0",data-translatey="-20")
+    div.crowdsale-contributions.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-scale="1.4")
+    div.crowdsale-crowd.animateme(data-when="enter", data-from="0.3", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.1", data-easing="linear")
+
+
+mixin daoFigure()
+  figure.dao.scrollme
+    div.dao-robot.animateme(data-when="enter", data-from="0.65", data-to="0.45", data-opacity="0", data-translatey="200", data-rotatez="-90")
+    div.dao-money.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200")
+    div.dao-arrows.animateme(data-when="enter", data-from="0.95", data-to="0.8", data-opacity="0", data-scale="1.5")
+    div.dao-crowd.animateme(data-when="enter", data-from="0.45", data-to="0", data-opacity="0", data-translatey="-250", data-translatex="10", data-rotatez="0", data-scale="1.1", data-easing="linear")
+    div.dao-ideas.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-40")
+
+
+mixin futureFigure()
+  figure.moon.scrollme
+    div.moon-stars.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="360", data-easing="linear")
+    div.moon-moon.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="720", data-easing="linear")
+    div.moon-rocket.animateme(data-when="span", data-from="0", data-to="1", data-translatey="-200", data-easing="linear")

--- a/views/mixins/recipes.jade
+++ b/views/mixins/recipes.jade
@@ -1,0 +1,300 @@
+mixin gethRecipe(header)
+  figure.geth.scrollme
+    div.geth-background.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatex="100")
+    div.geth-logo.animateme(data-when="enter", data-from="0.7", data-to="0.6", data-opacity="0")
+
+  if header != ""
+    h2 #{header}
+  h3 
+   div.number 1 
+   | Run and Setup 
+   strong Geth
+   | , the Command Line Interface
+
+  p Geth is the main tool of the Frontier release. You can use it to test the network, send ether (the network’s internal currency),  execute contracts, unlock your presale ether or make your computer into a supporting node to earn ether (ie. “mining”).
+
+  a(href="geth").button Install Geth
+
+  div.recipe
+    h4 You'll need:
+    ul
+      li 
+        input(type="checkbox") 
+        | Know how to use a command-line interface 
+      li 
+        input(type="checkbox") 
+        |  500 Mb free space (for the blockchain) 
+      li 
+        input(type="checkbox") 
+        |  Not be afraid of basic coding
+
+
+mixin etherRecipe(header)
+  figure.ether.scrollme
+    div.ether-screen.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
+    div.ether-pacman.animateme(data-when="span", data-from="0.6", data-to="0.5", data-opacity="0")
+    div.ether-arcade-back.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
+    div.ether-coin.animateme(data-when="span", data-from="0.6", data-to="0.4", data-translatey="-300")
+    div.ether-arcade-front.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
+    
+  if header != ""
+    h2 #{header}
+  h3
+   div.number 2
+   | Get Ether, the crypto-fuel of the Ethereum network
+  
+  p Ether is the internal currency of the system. All programs running on Ethereum need to pay the network for the consumed resources in ether, and <strong>anyone can setup a computer executing those programs to earn ether ("mining")</strong>. If you participated in the presale to fund Ethereum development or in one of our bug bounty programs, you should have a wallet file (.json) that will allow you to unlock your ether.
+  
+  p Otherwise you can get some from a friend; exchange bitcoin for it; or from one of the sites that give away free ether.
+  
+  a(href="ether").button Get Ether
+  
+  div.recipe
+    h4 You'll need:
+    ul
+      li 
+        input(type="checkbox") 
+        a(href="#install-geth") Geth 
+      li 
+        input(type="checkbox") 
+        |  One of these:
+        ul
+          li 
+            input(type="checkbox") 
+            |  Active Github account
+          li 
+            input(type="checkbox") 
+            |  Bitcoins to exchange
+          li 
+            input(type="checkbox") 
+            |  Computer with a modern GPU
+          li 
+            input(type="checkbox") 
+            |  Ether presale wallet
+          li 
+            input(type="checkbox") 
+            |  Generous friend with ether
+
+
+mixin greeterRecipe(header)
+  figure.greeter.scrollme
+    div.greeter-human.animateme(data-when="enter", data-from="0.4", data-to="0", data-opacity="0", data-translatex="-200")
+    div.greeter-robot.animateme(data-when="enter", data-from="0.5", data-to="0.2", data-opacity="0", data-translatex="200")
+    div.greeter-question.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0")
+    div.greeter-answer.animateme(data-when="enter", data-from="0.9", data-to="0.6", data-opacity="0")
+
+  if header != ""
+    h2 #{header}
+  h3 
+   div.number 3 
+   | Create the Greeter, your first live contract
+
+  p The greeter is a very simple contract that greets “Hello” when you poke it. It includes a very simple upgrade that turns it into a contract that will charge for telling jokes.
+
+  a(href="greeter").button Summon the Greeter 
+
+  div.recipe
+    h4 You'll need:
+    ul
+      li 
+        input(type="checkbox") 
+        a(href="#install-geth") Geth 
+      li 
+        input(type="checkbox") 
+        |  Desire to learn new things  
+      li 
+        input(type="checkbox") 
+        |  0.001 
+        a(href="#get-ether") ether 
+        | (approximatelly)
+      li 
+        input(type="checkbox") 
+        |  1 "knock knock" joke (optional)
+
+
+mixin tokenRecipe(header)
+  figure.coin.scrollme
+    div.coin-connection.animateme(data-when="enter", data-from="1", data-to="0.5", data-opacity="0", data-translatey="0")
+    div.coin-send.animateme(data-when="enter", data-from="0.9", data-to="0.8", data-opacity="0", data-translatey="-50", data-translatex="-200")
+    div.coin-users.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.5", data-rotate="45")
+    div.coin-coins.animateme(data-when="enter", data-from="0.6", data-to="0.4", data-opacity="0", data-scale="0.5", data-translatey="-10")
+
+  if header != ""
+    h2 #{header}
+  h3 
+   div.number 4 
+   | Design and issue your own cryptocurrency
+
+  p Create a tradeable digital token that can be used as a currency, a representation of an asset, a virtual share, proof of membership or anything you want. These tokens use a standard coin API, so it will be automatically compatible with any wallet, contract or exchange that also uses the same standard. The total amount of tokens in circulation can be controlled by anything you can program into it, or simply set to a fixed constant amount.
+
+  a(href="token").button Issue your token 
+
+  div.recipe
+    h4 You'll need:
+    ul
+      li 
+        input(type="checkbox") 
+        a(href="#install-geth") Geth 
+      li 
+        input(type="checkbox") 
+        |  Very basic programming skills 
+      li 
+        input(type="checkbox") 
+        |  0.002  
+        a(href="#get-ether") ether 
+        | (approximatelly)
+      li 
+        input(type="checkbox") 
+        |  1 cool coin name (optional)
+
+
+mixin crowdsaleRecipe(header)
+  figure.crowdsale.scrollme
+    div.crowdsale-logic.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-100", data-easing="linear")
+    div.crowdsale-robot.animateme(data-when="enter", data-from="0.5", data-to="0.3", data-opacity="0", data-translatey="-155", data-translatex="-30", data-scale="1.1", data-rotatez="90", data-easing="linear")
+    div.crowdsale-money.animateme(data-when="enter", data-from="0.8", data-to="0.6", data-opacity="0",data-translatey="-20")
+    div.crowdsale-contributions.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-scale="1.4")
+    div.crowdsale-crowd.animateme(data-when="enter", data-from="0.3", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.1", data-easing="linear")
+
+  if header != ""
+    h2 #{header}
+  h3 
+   div.number 5 
+   | Kickstart a project with a trustless crowdsale
+
+  p Are you already full of ideas to develop things in Ethereum? Maybe now you need some help and some funds to do that, but who would give money to someone they don’t trust?
+
+  p Using Ethereum you can create a contract that will hold contributors money until either a specific date or a given amount is reached. Depending on the outcome, the money is moved either to the project, or back to the contributors. All without requiring a central service provider, a clearing house or having to trust anyone. 
+
+  p You can even use the token you just created to keep track of ownership of prizes.
+
+  a(href="crowdsale").button Kickstart your project 
+
+  div.recipe
+    h4 You'll need:
+    ul
+      li 
+        input(type="checkbox") 
+        a(href="#install-geth") Geth 
+      li 
+        input(type="checkbox") 
+        | Basic programming skills 
+      li 
+        input(type="checkbox") 
+        | 0.004  
+        a(href="#get-ether") ether 
+        | (approximatelly)
+      li 
+        input(type="checkbox") 
+        | Ethereum-based
+        a(href="#crypto-currency") digital token 
+        | (track rewards)
+      li 
+        input(type="checkbox") 
+        | 1 good idea that needs funding
+
+mixin daoRecipe(header)
+  figure.dao.scrollme
+    div.dao-robot.animateme(data-when="enter", data-from="0.65", data-to="0.45", data-opacity="0", data-translatey="200", data-rotatez="-90")
+    div.dao-money.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200")
+    div.dao-arrows.animateme(data-when="enter", data-from="0.95", data-to="0.8", data-opacity="0", data-scale="1.5")
+    div.dao-crowd.animateme(data-when="enter", data-from="0.45", data-to="0", data-opacity="0", data-translatey="-250", data-translatex="10", data-rotatez="0", data-scale="1.1", data-easing="linear")
+    div.dao-ideas.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-40")
+
+  if header != ""
+    h2 #{header}
+  h3 
+   div.number 6 
+   | Create a democratic autonomous organization
+
+  p Now you have an idea, the funds and a lot of backers, what’s next? You now have to hire managers, find a trustable CFO to handle the funds, do board meetings and a bunch of paperwork. Or you can simply leave that to an Ethereum contract. It will accept proposals by any of your contributors and then put them all to a transparent vote.
+
+  p One of the advantadges of having a robot run your organization is that it is immune to any outside influence and it’s guaranteed to execute only what it is programmed to do. Your organization will never go offline or disappear and will always be available as long as the network exists.
+
+  a(href="dao").button Start your organization 
+
+  div.recipe
+    h4 You'll need:
+    ul
+      li 
+        input(type="checkbox") 
+        a(href="#install-geth") Geth 
+      li 
+        input(type="checkbox") 
+        | Basic programming skills 
+      li 
+        input(type="checkbox") 
+        | 0.008  
+        a(href="#get-ether") ether 
+        | (approximatelly) to create the contract 
+      li 
+        input(type="checkbox") 
+        | Ethereum-based
+        a(href="#crypto-currency") digital token  
+        | (voting right)
+      li 
+        input(type="checkbox") 
+        a(href="#crowdsale") Any amount of funds
+      li 
+        input(type="checkbox") 
+        | Bunch of ideas on where to spend your funds
+      li 
+        input(type="checkbox") 
+        | Friends to vote on these ideas (optional)
+
+
+mixin futureRecipe(header)
+  figure.moon.scrollme
+    div.moon-stars.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="360", data-easing="linear")
+    div.moon-moon.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="720", data-easing="linear")
+    div.moon-rocket.animateme(data-when="span", data-from="0", data-to="1", data-translatey="-200", data-easing="linear")
+    
+  if header != ""
+    h2 #{header}
+  h3 
+   div.number 7 
+   | Build a new kind of decentralized application
+
+  p Now it's your turn: start building what you want to create in Ethereum! Could your business be enhanced by existing in a cryptographically secure, decentralized, tamper proof network?
+
+  p There are many great projects being built right now, you should check them out. And since you are among the very few people in the world that can program a decentralized app, maybe some of them might need your help!
+
+  h4 Some projects using Ethereum
+
+  ul
+    li
+      a(href='http://augur.net') Augur 
+      | Decentralized prediction market built on Ethereum
+    li 
+      a(href='https://etherex.org/') Etherex 
+      | Ethereum based opensource exchange
+    li
+      a(href='https://www.theprotocol.tv/adept-demo-ibm-samsung') IBM 
+      | IBM/Samsung Internet of Things project
+    li 
+      a(href='http://ether.fund') Ether.fund              
+      | Ethereum blockchain services
+    li 
+      a(href='http://ethergit.com') Ether Git 
+      | Ethereum blockchain explorer
+    li 
+      a(href='http://airlock.me/') Airlock             
+      | Next generation keyless access protocol for smart property
+    li 
+      a(href='https://www.provenance.org') Provenance            
+      | Social business founded to open up the world of how things are made
+    li 
+      a(href='https://dgx.io/') DigiGlobal           
+      | the first Smart Asset company built on Ethereum
+    li 
+      a(href='http://weifund.io/') Wei.fund             
+      | A non-profit, decentralized crowdfunding platform built on Ethereum
+    li 
+      a(href='http://www.lazooz.net/')  Lazzoz            
+      | Decentralized Collaborative Transportation Web
+    li 
+      a(href='http://slock.it') Slock.it 
+      | "If you can lock it, we will let you rent, sell or share it."
+    li 
+      a(href='http://main.cubespawn.com') Cubespawn 
+      | Open source project to build cost sensitive, high quality, modular manufacturing machines

--- a/views/mixins/recipes.jade
+++ b/views/mixins/recipes.jade
@@ -1,15 +1,15 @@
+include figures.jade
+
 mixin gethRecipe(header)
-  figure.geth.scrollme
-    div.geth-background.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatex="100")
-    div.geth-logo.animateme(data-when="enter", data-from="0.7", data-to="0.6", data-opacity="0")
+  +gethFigure()
 
   if header != ""
     h2 #{header}
   h3 
-   div.number 1 
-   | Run and Setup 
-   strong Geth
-   | , the Command Line Interface
+    div.number 1 
+    | Run and Setup 
+    strong Geth
+    | , the Command Line Interface
 
   p Geth is the main tool of the Frontier release. You can use it to test the network, send ether (the network’s internal currency),  execute contracts, unlock your presale ether or make your computer into a supporting node to earn ether (ie. “mining”).
 
@@ -30,18 +30,13 @@ mixin gethRecipe(header)
 
 
 mixin etherRecipe(header)
-  figure.ether.scrollme
-    div.ether-screen.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-    div.ether-pacman.animateme(data-when="span", data-from="0.6", data-to="0.5", data-opacity="0")
-    div.ether-arcade-back.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-    div.ether-coin.animateme(data-when="span", data-from="0.6", data-to="0.4", data-translatey="-300")
-    div.ether-arcade-front.animateme(data-when="span", data-from="0.6", data-to="0", data-translatey="500")
-    
+  +etherFigure
+
   if header != ""
     h2 #{header}
   h3
-   div.number 2
-   | Get Ether, the crypto-fuel of the Ethereum network
+    div.number 2
+    | Get Ether, the crypto-fuel of the Ethereum network
   
   p Ether is the internal currency of the system. All programs running on Ethereum need to pay the network for the consumed resources in ether, and <strong>anyone can setup a computer executing those programs to earn ether ("mining")</strong>. If you participated in the presale to fund Ethereum development or in one of our bug bounty programs, you should have a wallet file (.json) that will allow you to unlock your ether.
   
@@ -61,33 +56,26 @@ mixin etherRecipe(header)
         ul
           li 
             input(type="checkbox") 
-            |  Active Github account
-          li 
-            input(type="checkbox") 
-            |  Bitcoins to exchange
-          li 
-            input(type="checkbox") 
             |  Computer with a modern GPU
           li 
             input(type="checkbox") 
-            |  Ether presale wallet
+            |  Generous friend with ether
           li 
             input(type="checkbox") 
-            |  Generous friend with ether
+            |  Bitcoins to exchange for
+          li 
+            input(type="checkbox") 
+            |  Ether presale wallet
 
 
 mixin greeterRecipe(header)
-  figure.greeter.scrollme
-    div.greeter-human.animateme(data-when="enter", data-from="0.4", data-to="0", data-opacity="0", data-translatex="-200")
-    div.greeter-robot.animateme(data-when="enter", data-from="0.5", data-to="0.2", data-opacity="0", data-translatex="200")
-    div.greeter-question.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0")
-    div.greeter-answer.animateme(data-when="enter", data-from="0.9", data-to="0.6", data-opacity="0")
+  +greeterFigure
 
   if header != ""
     h2 #{header}
   h3 
-   div.number 3 
-   | Create the Greeter, your first live contract
+    div.number 3 
+    | Create the Greeter, your first live contract
 
   p The greeter is a very simple contract that greets “Hello” when you poke it. It includes a very simple upgrade that turns it into a contract that will charge for telling jokes.
 
@@ -113,17 +101,13 @@ mixin greeterRecipe(header)
 
 
 mixin tokenRecipe(header)
-  figure.coin.scrollme
-    div.coin-connection.animateme(data-when="enter", data-from="1", data-to="0.5", data-opacity="0", data-translatey="0")
-    div.coin-send.animateme(data-when="enter", data-from="0.9", data-to="0.8", data-opacity="0", data-translatey="-50", data-translatex="-200")
-    div.coin-users.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.5", data-rotate="45")
-    div.coin-coins.animateme(data-when="enter", data-from="0.6", data-to="0.4", data-opacity="0", data-scale="0.5", data-translatey="-10")
+  +tokenFigure
 
   if header != ""
     h2 #{header}
   h3 
-   div.number 4 
-   | Design and issue your own cryptocurrency
+    div.number 4 
+    | Design and issue your own cryptocurrency
 
   p Create a tradeable digital token that can be used as a currency, a representation of an asset, a virtual share, proof of membership or anything you want. These tokens use a standard coin API, so it will be automatically compatible with any wallet, contract or exchange that also uses the same standard. The total amount of tokens in circulation can be controlled by anything you can program into it, or simply set to a fixed constant amount.
 
@@ -149,18 +133,13 @@ mixin tokenRecipe(header)
 
 
 mixin crowdsaleRecipe(header)
-  figure.crowdsale.scrollme
-    div.crowdsale-logic.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-100", data-easing="linear")
-    div.crowdsale-robot.animateme(data-when="enter", data-from="0.5", data-to="0.3", data-opacity="0", data-translatey="-155", data-translatex="-30", data-scale="1.1", data-rotatez="90", data-easing="linear")
-    div.crowdsale-money.animateme(data-when="enter", data-from="0.8", data-to="0.6", data-opacity="0",data-translatey="-20")
-    div.crowdsale-contributions.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-scale="1.4")
-    div.crowdsale-crowd.animateme(data-when="enter", data-from="0.3", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.1", data-easing="linear")
+  +crowdsaleFigure
 
   if header != ""
     h2 #{header}
   h3 
-   div.number 5 
-   | Kickstart a project with a trustless crowdsale
+    div.number 5 
+    | Kickstart a project with a trustless crowdsale
 
   p Are you already full of ideas to develop things in Ethereum? Maybe now you need some help and some funds to do that, but who would give money to someone they don’t trust?
 
@@ -194,18 +173,13 @@ mixin crowdsaleRecipe(header)
         | 1 good idea that needs funding
 
 mixin daoRecipe(header)
-  figure.dao.scrollme
-    div.dao-robot.animateme(data-when="enter", data-from="0.65", data-to="0.45", data-opacity="0", data-translatey="200", data-rotatez="-90")
-    div.dao-money.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-translatey="200")
-    div.dao-arrows.animateme(data-when="enter", data-from="0.95", data-to="0.8", data-opacity="0", data-scale="1.5")
-    div.dao-crowd.animateme(data-when="enter", data-from="0.45", data-to="0", data-opacity="0", data-translatey="-250", data-translatex="10", data-rotatez="0", data-scale="1.1", data-easing="linear")
-    div.dao-ideas.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-40")
+  +daoFigure
 
   if header != ""
     h2 #{header}
   h3 
-   div.number 6 
-   | Create a democratic autonomous organization
+    div.number 6 
+    | Create a democratic autonomous organization
 
   p Now you have an idea, the funds and a lot of backers, what’s next? You now have to hire managers, find a trustable CFO to handle the funds, do board meetings and a bunch of paperwork. Or you can simply leave that to an Ethereum contract. It will accept proposals by any of your contributors and then put them all to a transparent vote.
 
@@ -244,16 +218,13 @@ mixin daoRecipe(header)
 
 
 mixin futureRecipe(header)
-  figure.moon.scrollme
-    div.moon-stars.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="360", data-easing="linear")
-    div.moon-moon.animateme(data-when="span", data-from="0", data-to="1", data-translatey="100", data-rotatez="720", data-easing="linear")
-    div.moon-rocket.animateme(data-when="span", data-from="0", data-to="1", data-translatey="-200", data-easing="linear")
-    
+  +futureFigure
+
   if header != ""
     h2 #{header}
   h3 
-   div.number 7 
-   | Build a new kind of decentralized application
+    div.number 7 
+    | Build a new kind of decentralized application
 
   p Now it's your turn: start building what you want to create in Ethereum! Could your business be enhanced by existing in a cryptographically secure, decentralized, tamper proof network?
 

--- a/views/token.jade
+++ b/views/token.jade
@@ -1,6 +1,7 @@
 extends layout
 
 block content
+  include mixins/recipes.jade
   include warning.jade
 
   div#tutorial-start.main-tutorial.inner-tutorial.even
@@ -31,54 +32,8 @@ block content
         div.col-md-12
           include:md content/token.md        
 
-
   div.main-tutorial.hidden.even
     div.container   
       div.row
         div.col-md-12.tutorial
-
-          figure.crowdsale.scrollme
-            div.crowdsale-logic.animateme(data-when="enter", data-from="0.8", data-to="0.7", data-opacity="0", data-translatey="-100", data-easing="linear")
-            div.crowdsale-robot.animateme(data-when="enter", data-from="0.5", data-to="0.3", data-opacity="0", data-translatey="-155", data-translatex="-30", data-scale="1.1", data-rotatez="90", data-easing="linear")
-            div.crowdsale-money.animateme(data-when="enter", data-from="0.8", data-to="0.6", data-opacity="0",data-translatey="-20")
-            div.crowdsale-contributions.animateme(data-when="enter", data-from="0.7", data-to="0.5", data-opacity="0", data-scale="1.4")
-            div.crowdsale-crowd.animateme(data-when="enter", data-from="0.3", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.1", data-easing="linear")
-
-          h2 What's next
-          h3 
-           div.number 5 
-           | Kickstart a project with a trustless crowdsale
-
-          p Are you already full of ideas to develop things in ethereum? Maybe now you need some help and some funds to do that, but who would give money to someone they don’t trust? Using Ethereum you can create a contract that will hold contributors money until either a specific date is reached or until a given amount is reached. All without requiring a central service provider, a clearing house or having to trust anyone. 
-
-          p You can even use the token you just created to keep track of ownership of prizes.
-
-
-          a(href="crowdsale").button Kickstart your project 
-
-          div.recipe
-            h4 You'll need:
-            ul
-              li 
-                input(type="checkbox") 
-                a(href="geth") Geth 
-              li 
-                input(type="checkbox") 
-                | Basic programming skills 
-              li 
-                input(type="checkbox") 
-                | 0.004 ether (approximatelly)
-              li 
-                input(type="checkbox") 
-                | an ethereum-based  
-                a(href="token") digital token 
-                | (will be used to keep track of the rewards) 
-              li 
-                input(type="checkbox") 
-                | 1 good idea that needs funding
-
-
-
-
-          
-
+          +crowdsaleRecipe("What's next?")

--- a/views/token.jade
+++ b/views/token.jade
@@ -14,11 +14,7 @@ block content
             a(href="/greeter").previous Previous 
             a(href="/crowdsale").next Next 
           
-          figure.coin.scrollme
-            div.coin-connection.animateme(data-when="enter", data-from="1", data-to="0.5", data-opacity="0", data-translatey="0")
-            div.coin-send.animateme(data-when="enter", data-from="0.9", data-to="0.8", data-opacity="0", data-translatey="-50", data-translatex="-200")
-            div.coin-users.animateme(data-when="enter", data-from="0.5", data-to="0", data-opacity="0", data-translatey="-100", data-scale="1.5", data-rotate="45")
-            div.coin-coins.animateme(data-when="enter", data-from="0.6", data-to="0.4", data-opacity="0", data-scale="0.5", data-translatey="-10")
+          +tokenFigure
 
           h2.animateme(data-when="span", data-from="0.6", data-to="0.3", data-opacity="0", data-translatey="200") Create your own crypto-currency
 


### PR DESCRIPTION
- Abstract the recipe summaries into individual mixins so that we can reuse the same code on the index page as well as in the "What's next" sections. I needed the mixins to support setting the optional header ("What's next"), but feel free to work around it if there's a better solution not requiring mixins, only templates.
- Separated out the recipe pictures too since they were also used in multiple locations (recipe summary + recipe page). This actually caught an issue where the idea lightbulbs were missing from the dao page :) The geth figure was different between the summary and detail page, so I've left both versions in and select with a switch. Maybe you could take a look if it would make sense to convert it to a single version.
